### PR TITLE
[PROD-1328] Update chainId type from uint16 to uint64

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/forge-std"]
+	path = lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ Install necessary building tools:
 # if error, maybe change /etc/hosts
 ./scripts/install_foundry.sh
 
+# if lib/forge-std is empty or missing, run the following commands
+rm -rf lib/forge-std
+git submodule update --init --recursive
+
+# if the above doesn't work, create an empty tmp repo, run the following command,
+# and copy the lib/forge-std in the tmp repo to core-contracts/lib/forge-std
+forge install foundry-rs/forge-std
+
 # install jq
 brew install jq
 

--- a/src/contracts/INimbleEvents.sol
+++ b/src/contracts/INimbleEvents.sol
@@ -18,7 +18,7 @@ interface INimbleEvents {
         string modelName
     );
 
-    event BatchPredictionFeedUpdate(uint16 chainId, uint64 sequenceNumber);
+    event BatchPredictionFeedUpdate(uint64 chainId, uint64 sequenceNumber);
 
     event NimbleGetActionFeeUpdate(uint64 oldFee, uint64 newFee);
 

--- a/src/contracts/MockNimble.sol
+++ b/src/contracts/MockNimble.sol
@@ -8,10 +8,10 @@ import "./NimbleGovernance.sol";
 contract MockNimble is AbstractNimble, NimbleGovernance {
     mapping(string => NimbleStructs.PredictionFeed) predictionFeeds;
     uint64 sequenceNumber;
-    uint16 chainId;
+    uint64 chainId;
 
     constructor(
-        uint16 chainId_,
+        uint64 chainId_,
         uint64 getActionfee_,
         uint64 updateActionfee_
     ) {


### PR DESCRIPTION
Changes:
- Update chainId type from uint16 to uint64

Because Mumbai's ChainID is 80001
<img width="328" alt="image" src="https://github.com/nimble-technology/nimble-prediction-contracts/assets/152596496/06475f42-3e3c-4f50-82b0-49335d4ca363">
